### PR TITLE
Nested types

### DIFF
--- a/spec/byte_format_spec.cr
+++ b/spec/byte_format_spec.cr
@@ -20,17 +20,6 @@ module ByteFormatTest
       @x == other.x && @y == other.y
     end
   end
-
-  class Nested
-    getter obj : Obj
-
-    def initialize(@obj)
-    end
-
-    def ==(other : self)
-      @obj == other.obj
-    end
-  end
 end
 
 private def assert_byte_format_serialization(object : T, bytes : Bytes, line = __LINE__) forall T
@@ -59,11 +48,11 @@ describe Crystalizer::ByteFormat do
   end
 
   describe "nested class" do
-    point = ByteFormatTest::Obj.new
-    nested = ByteFormatTest::Nested.new(point)
-    bytes = Bytes[1, 0, 0, 0, 97, 0]
+    nested = Nested.new("bar")
+    obj = Parent.new("foo", nested)
+    bytes = Bytes[102, 111, 111, 0, 98, 97, 114, 0]
 
-    assert_byte_format_serialization nested, bytes
+    assert_byte_format_serialization obj, bytes
   end
 
   describe Array do

--- a/spec/byte_format_spec.cr
+++ b/spec/byte_format_spec.cr
@@ -20,6 +20,17 @@ module ByteFormatTest
       @x == other.x && @y == other.y
     end
   end
+
+  class Nested
+    getter obj : Obj
+
+    def initialize(@obj)
+    end
+
+    def ==(other : self)
+      @obj == other.obj
+    end
+  end
 end
 
 private def assert_byte_format_serialization(object : T, bytes : Bytes, line = __LINE__) forall T
@@ -45,6 +56,14 @@ describe Crystalizer::ByteFormat do
     bytes = Bytes[1, 0, 0, 0, 97, 0]
 
     assert_byte_format_serialization point, bytes
+  end
+
+  describe "nested class" do
+    point = ByteFormatTest::Obj.new
+    nested = ByteFormatTest::Nested.new(point)
+    bytes = Bytes[1, 0, 0, 0, 97, 0]
+
+    assert_byte_format_serialization nested, bytes
   end
 
   describe Array do

--- a/spec/format_helper.cr
+++ b/spec/format_helper.cr
@@ -21,13 +21,26 @@ class Obj
 end
 
 class Nested
-  getter obj : Obj
+  getter str : String
 
-  def initialize(@obj)
+  def initialize(@str)
   end
 
   def ==(other : self)
-    @obj == other.obj
+    @str == other.str
+  end
+end
+
+class Parent
+  getter str : String
+
+  getter nested : Nested
+
+  def initialize(@str, @nested)
+  end
+
+  def ==(other : self)
+    @str == other.str && @nested == other.nested
   end
 end
 

--- a/spec/format_helper.cr
+++ b/spec/format_helper.cr
@@ -20,6 +20,17 @@ class Obj
   end
 end
 
+class Nested
+  getter obj : Obj
+
+  def initialize(@obj)
+  end
+
+  def ==(other : self)
+    @obj == other.obj
+  end
+end
+
 enum Enu
   A
   B

--- a/spec/json_spec.cr
+++ b/spec/json_spec.cr
@@ -27,6 +27,14 @@ describe Crystalizer::JSON do
     assert_json_serialization obj, json_obj
   end
 
+  describe "nested class" do
+    obj = Obj.new ["a", "b"]
+    nested = Nested.new(obj)
+    json_obj = %({"obj":{"ary":["a","b"]}})
+
+    assert_json_serialization nested, json_obj
+  end
+
   describe Crystalizer::JSON::Any do
     json = %({"ary":["a",1]})
     any = Crystalizer::JSON.parse json

--- a/spec/json_spec.cr
+++ b/spec/json_spec.cr
@@ -28,11 +28,11 @@ describe Crystalizer::JSON do
   end
 
   describe "nested class" do
-    obj = Obj.new ["a", "b"]
-    nested = Nested.new(obj)
-    json_obj = %({"obj":{"ary":["a","b"]}})
+    nested = Nested.new("bar")
+    obj = Parent.new("foo", nested)
+    json_obj = %({"str":"foo","nested":{"str":"bar"}})
 
-    assert_json_serialization nested, json_obj
+    assert_json_serialization obj, json_obj
   end
 
   describe Crystalizer::JSON::Any do

--- a/spec/yaml_spec.cr
+++ b/spec/yaml_spec.cr
@@ -38,6 +38,21 @@ describe Crystalizer::YAML do
     assert_yaml_serialization obj, yaml_obj
   end
 
+  describe "nested class" do
+    obj = Obj.new ["a", "b"]
+    nested = Nested.new(obj)
+    yaml_obj = <<-E
+    ---
+    obj:
+      ary:
+      - a
+      - b
+
+    E
+
+    assert_yaml_serialization nested, yaml_obj
+  end
+
   describe Crystalizer::YAML::Any do
     yaml = <<-E
     ---

--- a/spec/yaml_spec.cr
+++ b/spec/yaml_spec.cr
@@ -39,18 +39,17 @@ describe Crystalizer::YAML do
   end
 
   describe "nested class" do
-    obj = Obj.new ["a", "b"]
-    nested = Nested.new(obj)
+    nested = Nested.new("bar")
+    obj = Parent.new("foo", nested)
     yaml_obj = <<-E
     ---
-    obj:
-      ary:
-      - a
-      - b
+    str: foo
+    nested:
+      str: bar
 
     E
 
-    assert_yaml_serialization nested, yaml_obj
+    assert_yaml_serialization obj, yaml_obj
   end
 
   describe Crystalizer::YAML::Any do

--- a/src/byte_format/serialize.cr
+++ b/src/byte_format/serialize.cr
@@ -47,7 +47,7 @@ struct Crystalizer::ByteFormat
   end
 
   def serialize(object : O) forall O
-    Crystalizer.each_ivar(object) do |_, value|
+    object.each_ivar do |_, value|
       serialize value
     end
   end

--- a/src/byte_format/serialize.cr
+++ b/src/byte_format/serialize.cr
@@ -47,8 +47,12 @@ struct Crystalizer::ByteFormat
   end
 
   def serialize(object : O) forall O
-    object.each_ivar do |_, value|
-      serialize value
-    end
+    {% for ivar in O.instance_vars %}
+    {% ann = ivar.annotation(::Crystalizer::Field) %}
+      {% unless ann && ann[:ignore] %}
+        {% key = ((ann && ann[:key]) || ivar).id.stringify %}
+        serialize object.@{{ivar}}
+      {% end %}
+    {% end %}
   end
 end

--- a/src/byte_format/serialize.cr
+++ b/src/byte_format/serialize.cr
@@ -47,12 +47,16 @@ struct Crystalizer::ByteFormat
   end
 
   def serialize(object : O) forall O
-    {% for ivar in O.instance_vars %}
-    {% ann = ivar.annotation(::Crystalizer::Field) %}
-      {% unless ann && ann[:ignore] %}
-        {% key = ((ann && ann[:key]) || ivar).id.stringify %}
-        serialize object.@{{ivar}}
-      {% end %}
+    Crystalizer.each_ivar(object) do |_, value|
+      de_unionize(value)
+    end
+  end
+
+  private def de_unionize(object : U) forall U
+    {% for u in U.union_types %}
+      if object.is_a? {{u}}
+        serialize object
+      end
     {% end %}
   end
 end

--- a/src/crystalizer.cr
+++ b/src/crystalizer.cr
@@ -1,24 +1,9 @@
+require "./ext/object"
 require "./field"
 require "./object"
 require "./variable"
 
 module Crystalizer
-  # Yields each instance variable with its key, value and `Variable` metadata.
-  protected def self.each_ivar(object : O, &) forall O
-    {% for ivar in O.instance_vars %}
-      {% ann = ivar.annotation(::Crystalizer::Field) %}
-      {% unless ann && ann[:ignore] %}
-        {% key = ((ann && ann[:key]) || ivar).id.stringify %}
-        yield {{key}}, object.@{{ivar}}, Variable.new(
-            type: {{ivar.type}},
-            annotations: {{ann && ann.named_args}},
-            nilable: {{ivar.type.nilable?}},
-            has_default: {{ivar.has_default_value?}}
-          )
-      {% end %}
-    {% end %}
-  end
-
   # Creates a new `Tuple` instance from a Tuple class.
   protected def self.create_tuple(tuple : Tuple.class, &)
     internal_create_tuple tuple do |type|

--- a/src/crystalizer.cr
+++ b/src/crystalizer.cr
@@ -4,6 +4,21 @@ require "./object"
 require "./variable"
 
 module Crystalizer
+  protected def self.each_ivar(object : O, &) forall O
+    {% for ivar in O.instance_vars %}
+      {% ann = ivar.annotation(::Crystalizer::Field) %}
+      {% unless ann && ann[:ignore] %}
+        {% key = ((ann && ann[:key]) || ivar).id.stringify %}
+        yield {{key}}, object.@{{ivar}}, Variable.new(
+            type: {{ivar.type}},
+            annotations: {{ann && ann.named_args}},
+            nilable: {{ivar.type.nilable?}},
+            has_default: {{ivar.has_default_value?}}
+          )
+      {% end %}
+    {% end %}
+  end
+  
   # Creates a new `Tuple` instance from a Tuple class.
   protected def self.create_tuple(tuple : Tuple.class, &)
     internal_create_tuple tuple do |type|

--- a/src/ext/object.cr
+++ b/src/ext/object.cr
@@ -1,18 +1,18 @@
-class Object
-  def each_ivar(&block)
-    {% begin %}
-      {% for ivar in @type.instance_vars %}
-        {% ann = ivar.annotation(::Crystalizer::Field) %}
-        {% unless ann && ann[:ignore] %}
-          {% key = ((ann && ann[:key]) || ivar).id.stringify %}
-          yield {{key}}, @{{ivar}}, Crystalizer::Variable.new(
-              type: {{ivar.type}},
-              annotations: {{ann && ann.named_args}},
-              nilable: {{ivar.type.nilable?}},
-              has_default: {{ivar.has_default_value?}}
-            )
-        {% end %}
-      {% end %}
-    {% end %}
-  end
-end
+# class Object
+#   def each_ivar(&block)
+#     {% begin %}
+#       {% for ivar in @type.instance_vars %}
+#         {% ann = ivar.annotation(::Crystalizer::Field) %}
+#         {% unless ann && ann[:ignore] %}
+#           {% key = ((ann && ann[:key]) || ivar).id.stringify %}
+#           yield {{key}}, @{{ivar}}, Crystalizer::Variable.new(
+#               type: {{ivar.type}},
+#               annotations: {{ann && ann.named_args}},
+#               nilable: {{ivar.type.nilable?}},
+#               has_default: {{ivar.has_default_value?}}
+#             )
+#         {% end %}
+#       {% end %}
+#     {% end %}
+#   end
+# end

--- a/src/ext/object.cr
+++ b/src/ext/object.cr
@@ -1,0 +1,18 @@
+class Object
+  def each_ivar(&block)
+    {% begin %}
+      {% for ivar in @type.instance_vars %}
+        {% ann = ivar.annotation(::Crystalizer::Field) %}
+        {% unless ann && ann[:ignore] %}
+          {% key = ((ann && ann[:key]) || ivar).id.stringify %}
+          yield {{key}}, @{{ivar}}, Crystalizer::Variable.new(
+              type: {{ivar.type}},
+              annotations: {{ann && ann.named_args}},
+              nilable: {{ivar.type.nilable?}},
+              has_default: {{ivar.has_default_value?}}
+            )
+        {% end %}
+      {% end %}
+    {% end %}
+  end
+end

--- a/src/json/serialize.cr
+++ b/src/json/serialize.cr
@@ -13,11 +13,15 @@ module Crystalizer::JSON
 
   def self.serialize(builder : ::JSON::Builder, object : O) forall O
     builder.object do
-      object.each_ivar do |key, value|
-        builder.field key do
-          serialize builder, value
-        end
-      end
+      {% for ivar in O.instance_vars %}
+      {% ann = ivar.annotation(::Crystalizer::Field) %}
+        {% unless ann && ann[:ignore] %}
+          {% key = ((ann && ann[:key]) || ivar).id.stringify %}
+          builder.field {{ key.id.stringify }} do
+            serialize builder, object.@{{ivar}}
+          end
+        {% end %}
+      {% end %}
     end
   end
 

--- a/src/json/serialize.cr
+++ b/src/json/serialize.cr
@@ -13,7 +13,7 @@ module Crystalizer::JSON
 
   def self.serialize(builder : ::JSON::Builder, object : O) forall O
     builder.object do
-      Crystalizer.each_ivar(object) do |key, value|
+      object.each_ivar do |key, value|
         builder.field key do
           serialize builder, value
         end

--- a/src/yaml/serialize.cr
+++ b/src/yaml/serialize.cr
@@ -15,10 +15,14 @@ module Crystalizer::YAML
 
   def self.serialize(builder : ::YAML::Nodes::Builder, object : O) forall O
     builder.mapping do
-      object.each_ivar do |key, value|
-        serialize builder, key
-        serialize builder, value
-      end
+      {% for ivar in O.instance_vars %}
+      {% ann = ivar.annotation(::Crystalizer::Field) %}
+        {% unless ann && ann[:ignore] %}
+          {% key = ((ann && ann[:key]) || ivar).id.stringify %}
+          serialize builder, {{ key.id.stringify }}
+          serialize builder, object.@{{ivar}}
+        {% end %}
+      {% end %}
     end
   end
 

--- a/src/yaml/serialize.cr
+++ b/src/yaml/serialize.cr
@@ -15,7 +15,7 @@ module Crystalizer::YAML
 
   def self.serialize(builder : ::YAML::Nodes::Builder, object : O) forall O
     builder.mapping do
-      Crystalizer.each_ivar(object) do |key, value|
+      object.each_ivar do |key, value|
         serialize builder, key
         serialize builder, value
       end


### PR DESCRIPTION
This PR adds support for nested classes. Originally serialization would only work if the types within a class were primitives, as soon as there was a primitive and a non-primitive as instance variables in a class, `Crystalizer.each_ivar` would fail. I posted a complete explanation [on Gitter](https://gitter.im/crystal-lang/crystal?at=600a5d96a2354e44ac9d5ef7).